### PR TITLE
Update README to point to correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: opticdev/optic-changelog
+      - uses: opticdev/github-actions-optic-changelog
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```


### PR DESCRIPTION
This is something I forgot to do when I moved the repository into the `opticdev` org.