### PR TITLE
Revert "Update README to point to correct repository"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: opticdev/github-actions-optic-changelog
+      - uses: opticdev/optic-changelog
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```


### PR DESCRIPTION
So I read that PR wrong -- it was correct as it was, and we changed the repo name to be shorter, which is what we actually want.